### PR TITLE
change the default terminal font to be monospace

### DIFF
--- a/projects/CMD_Terminal_Simulator/assets/css/effects.css
+++ b/projects/CMD_Terminal_Simulator/assets/css/effects.css
@@ -201,7 +201,7 @@
     /* text customize */
     margin: 0; 
     line-height: 1.25;
-    font-family: 'Ubuntu', monospace;
+    font-family: 'Ubuntu Mono', 'Ubuntu', monospace;
     font-size: 17px; 
     font-weight:100;
     padding: 0 1px;


### PR DESCRIPTION
The default Ubuntu font is not monospace, but sans-serif. On a Linux machine the display is off